### PR TITLE
Fixes file names

### DIFF
--- a/cypress/integration/e2e/submitting_reports.js
+++ b/cypress/integration/e2e/submitting_reports.js
@@ -129,7 +129,7 @@ describe('Submitting data creates a valid report into database', function() {
         }
       }).should((response) => {
         const { fileName, data } = response.body
-        expect(fileName).to.contain('TKTTEST%5.7.19-')
+        expect(fileName).to.contain('TKTTEST%')
         expect(fileName).to.contain('V1-S2019.dat')
         expect(data).to.equal(
           '010000003##1#TKTTEST#tkt:n kurssi#5.7.2019#0#2#106##000000-000A#1#H523#####5,0\n011000002##6#TKTTEST#tkt:n kurssi#5.7.2019#0#Hyv.#106##000000-000A#1#H523#####2,0\n011100009##6#TKTTEST#tkt:n kurssi#5.7.2019#0#Hyv.#106##000000-000A#1#H523#####8,0\n011110002##1#TKTTEST#tkt:n kurssi#5.7.2019#0#Hyv.#106##000000-000A#1#H523#####8,0'
@@ -184,7 +184,7 @@ describe('Submitting data creates a valid report into database', function() {
         }
       }).should((response) => {
         const { fileName, data } = response.body
-        expect(fileName).to.contain('TKTTEST%5.7.19-')
+        expect(fileName).to.contain('TKTTEST%')
         expect(fileName).to.contain('-V1-S2019.dat')
         expect(data).to.equal(
           '010000003##1#TKTTEST#tkt:n kurssi#5.7.2019#0#2#106##000000-000A#1#H523#####5,0\n011000002##6#TKTTEST#tkt:n kurssi#5.7.2019#0#Hyv.#106##000000-000A#1#H523#####2,0\n011100009##6#TKTTEST#tkt:n kurssi#5.7.2019#0#Hyv.#106##000000-000A#1#H523#####8,0\n011110002##1#TKTTEST#tkt:n kurssi#5.7.2019#0#Hyv.#106##000000-000A#1#H523#####8,0'

--- a/cypress/integration/e2e/submitting_reports.js
+++ b/cypress/integration/e2e/submitting_reports.js
@@ -73,7 +73,7 @@ describe('Submitting data creates a valid report into database', function() {
         }
       }).should((response) => {
         const { fileName, data } = response.body
-        expect(fileName).to.contain('AYTKTTEST%5.7.19')
+        expect(fileName).to.contain('AYTKTTEST%')
         expect(fileName).to.contain('-V1-S2019.dat')
         expect(data).to.equal(
           '010000003##1#AYTKTTEST#avoimen kurssi#5.7.2019#0#2#106##000000-000B#1#H930#11#93013#3##5,0\n011000002##1#AYTKTTEST#avoimen kurssi#5.7.2019#0#Hyv.#106##000000-000B#1#H930#11#93013#3##2,0\n011100009##1#AYTKTTEST#avoimen kurssi#5.7.2019#0#Hyv.#106##000000-000B#1#H930#11#93013#3##8,0\n011110002##1#AYTKTTEST#avoimen kurssi#5.7.2019#0#Hyv.#106##000000-000B#1#H930#11#93013#3##8,0'

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "husky": "^1.3.1",
     "mini-css-extract-plugin": "^0.5.0",
     "module-alias": "^2.1.0",
+    "moment": "^2.24.0",
     "node-cron": "^2.0.3",
     "nodemailer": "^6.1.1",
     "optimize-css-assets-webpack-plugin": "^5.0.1",

--- a/server/scripts/processManualEntry.js
+++ b/server/scripts/processManualEntry.js
@@ -85,8 +85,9 @@ const processManualEntry = async ({ graderId, courseId, date, data }) => {
     .join('\n')
 
   const savedReport = await db.reports.create({
-    fileName: `${course.courseCode}%${moment().format('DD.MM.YY-HHmmss')}
-    -V1-S2019.dat`,
+    fileName: `${course.courseCode}%${moment().format(
+      'DD.MM.YY-HHmmss'
+    )}-V1-S2019.dat`,
     data: report
   })
 

--- a/server/scripts/processManualEntry.js
+++ b/server/scripts/processManualEntry.js
@@ -1,3 +1,4 @@
+var moment = require('moment')
 const db = require('../models/index')
 const {
   isValidStudentId,
@@ -19,15 +20,6 @@ const LANGUAGES = {
 const ORGANISATION_RELATED_PARAMETERS = {
   AYTKT: '#1#H930#11#93013#3##',
   TKT: '#1#H523#####'
-}
-
-const shortDate = (date) => {
-  const now = () => new Date(Date.now())
-  const timestamp = `${now().getHours()}:${now().getMinutes()}:${now().getSeconds()}`
-  const splitDate = date.split('.')
-  return `${splitDate[0]}.${splitDate[1]}.${splitDate[2].substring(
-    2
-  )}-${timestamp}`
 }
 
 const validateEntry = ({
@@ -93,7 +85,8 @@ const processManualEntry = async ({ graderId, courseId, date, data }) => {
     .join('\n')
 
   const savedReport = await db.reports.create({
-    fileName: `${course.courseCode}%${shortDate(date)}-V1-S2019.dat`,
+    fileName: `${course.courseCode}%${moment().format('DD.MM.YY-HHmmss')}
+    -V1-S2019.dat`,
     data: report
   })
 


### PR DESCRIPTION
Using colons (:) in file name timestamps was a bad idea. Also adds frontal zeroes to timestamps (powered by Moment).